### PR TITLE
Add missing timeouts to requests.get

### DIFF
--- a/bookwyrm/activitypub/base_activity.py
+++ b/bookwyrm/activitypub/base_activity.py
@@ -423,6 +423,7 @@ def get_activitypub_data(url):
                 "Date": now,
                 "Signature": make_signature("get", sender, url, now),
             },
+            timeout=15
         )
     except requests.RequestException:
         raise ConnectorException()

--- a/bookwyrm/activitypub/base_activity.py
+++ b/bookwyrm/activitypub/base_activity.py
@@ -423,7 +423,7 @@ def get_activitypub_data(url):
                 "Date": now,
                 "Signature": make_signature("get", sender, url, now),
             },
-            timeout=15
+            timeout=15,
         )
     except requests.RequestException:
         raise ConnectorException()

--- a/bookwyrm/isbn/isbn.py
+++ b/bookwyrm/isbn/isbn.py
@@ -26,7 +26,7 @@ class IsbnHyphenator:
 
     def update_range_message(self) -> None:
         """Download the range message xml file and save it locally"""
-        response = requests.get(self.__range_message_url)
+        response = requests.get(self.__range_message_url, timeout=15)
         with open(self.__range_file_path, "w", encoding="utf-8") as file:
             file.write(response.text)
         self.__element_tree = None


### PR DESCRIPTION
An instance of requests.get in isbn.py and one in bookwyrm/activitypub/base_activity.py lack a timeout, and this commit adds one with a default of 15 as used other places in the code, where requests.get does already have a timeout.